### PR TITLE
Fix logic to raise error when property is missing

### DIFF
--- a/terraform_validate/fixtures/boolean_compare/1.tf
+++ b/terraform_validate/fixtures/boolean_compare/1.tf
@@ -1,6 +1,7 @@
 resource "aws_db_instance" "rds_db_instance" {
   storage_encrypted1 = true
-#  storage_encrypted3 = "True"
-#  storage_encrypted4 = "true"
-#  storage_encrypted5 = "trUE"
+  storage_encrypted2 = true
+  storage_encrypted3 = "True"
+  storage_encrypted4 = "true"
+  storage_encrypted5 = "trUE"
 }

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -289,7 +289,7 @@ class TerraformResourceList:
             for resource in self.resource_list:
                 if property_name in resource.config.keys():
                     list.properties.append(TerraformProperty(resource.type,resource.name,property_name,resource.config[property_name]))
-		else:
+                else:
                     errors.append("[{0}.{1}] should have property: '{2}'".format(resource.type,resource.name,property_name))
 
         if len(errors) > 0:

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -289,7 +289,7 @@ class TerraformResourceList:
             for resource in self.resource_list:
                 if property_name in resource.config.keys():
                     list.properties.append(TerraformProperty(resource.type,resource.name,property_name,resource.config[property_name]))
-                elif self.validator.raise_error_if_property_missing:
+                else:
                     errors.append("[{0}.{1}] should have property: '{2}'".format(resource.type,resource.name,property_name))
 
         if len(errors) > 0:

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -289,8 +289,6 @@ class TerraformResourceList:
             for resource in self.resource_list:
                 if property_name in resource.config.keys():
                     list.properties.append(TerraformProperty(resource.type,resource.name,property_name,resource.config[property_name]))
-                elif self.validator.raise_error_if_property_missing:
-                    errors.append("[{0}.{1}] should have property: '{2}'".format(resource.type,resource.name,property_name))
 		else:
                     errors.append("[{0}.{1}] should have property: '{2}'".format(resource.type,resource.name,property_name))
 

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -289,7 +289,9 @@ class TerraformResourceList:
             for resource in self.resource_list:
                 if property_name in resource.config.keys():
                     list.properties.append(TerraformProperty(resource.type,resource.name,property_name,resource.config[property_name]))
-                else:
+                elif self.validator.raise_error_if_property_missing:
+                    errors.append("[{0}.{1}] should have property: '{2}'".format(resource.type,resource.name,property_name))
+		else:
                     errors.append("[{0}.{1}] should have property: '{2}'".format(resource.type,resource.name,property_name))
 
         if len(errors) > 0:


### PR DESCRIPTION
Test Case: Validate that aws_instance have specific tags (for eg - name, team)

Current code passes for following code which is not true

resource "aws_instance" "web" {
  ami           = "${data.aws_ami.ubuntu.id}"
  instance_type = "t2.micro"
}

This fix will raise error if there is no declaration of a property
